### PR TITLE
[core] Replace useSyncExternalStoreWithSelector with a local memoized selection

### DIFF
--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -32,8 +32,6 @@ export default function getBabelConfig(api) {
   if (removePropTypesPlugin) {
     removePropTypesPlugin[1] ??= {};
     removePropTypesPlugin[1].mode = 'unsafe-wrap';
-    removePropTypesPlugin[1].ignoreFilenames ??= [];
-    removePropTypesPlugin[1].ignoreFilenames.push('DataGrid.tsx', 'DataGridPro.tsx');
   }
   const displayNamePlugin = baseConfig.plugins.find(
     (p) => p[2] === '@mui/internal-babel-plugin-display-name',

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/gestureHooks/useRegisterZoomGestures.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/gestureHooks/useRegisterZoomGestures.ts
@@ -1,0 +1,59 @@
+'use client';
+import * as React from 'react';
+import { type ChartPlugin } from '@mui/x-charts/internals';
+import {
+  PanGesture,
+  PinchGesture,
+  PressAndDragGesture,
+  TapAndDragGesture,
+  TapGesture,
+  TurnWheelGesture,
+} from '@mui/x-internal-gestures/core';
+import { type UseChartProZoomSignature } from '../useChartProZoom.types';
+
+/**
+ * Registers the gestures required by the zoom feature.
+ * They are registered here instead of in the core interaction listener plugin
+ * so their implementations are only bundled with the zoom plugin.
+ */
+export const useRegisterZoomGestures = ({
+  instance,
+}: Pick<Parameters<ChartPlugin<UseChartProZoomSignature>>[0], 'instance'>) => {
+  React.useEffect(() => {
+    instance.registerGestures([
+      new PanGesture({
+        name: 'zoomPan',
+        threshold: 0,
+        preventIf: ['zoomTapAndDrag', 'zoomPressAndDrag'],
+      }),
+      new PinchGesture({
+        name: 'zoomPinch',
+        threshold: 5,
+      }),
+      new TurnWheelGesture({
+        name: 'zoomTurnWheel',
+        sensitivity: 0.01,
+        initialDelta: 1,
+        passive: false,
+      }),
+      new TurnWheelGesture({
+        name: 'panTurnWheel',
+        sensitivity: 0.5,
+        passive: false,
+      }),
+      new TapAndDragGesture({
+        name: 'zoomTapAndDrag',
+        dragThreshold: 10,
+      }),
+      new PressAndDragGesture({
+        name: 'zoomPressAndDrag',
+        dragThreshold: 10,
+        preventIf: ['zoomPinch'],
+      }),
+      new TapGesture({
+        name: 'zoomDoubleTapReset',
+        taps: 2,
+      }),
+    ]);
+  }, [instance]);
+};

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -31,6 +31,7 @@ import { usePanOnDrag } from './gestureHooks/usePanOnDrag';
 import { usePanOnWheel } from './gestureHooks/usePanOnWheel';
 import { useZoomOnTapAndDrag } from './gestureHooks/useZoomOnTapAndDrag';
 import { usePanOnPressAndDrag } from './gestureHooks/usePanOnPressAndDrag';
+import { useRegisterZoomGestures } from './gestureHooks/useRegisterZoomGestures';
 import { useZoomOnBrush } from './gestureHooks/useZoomOnBrush';
 import { useZoomOnDoubleTapReset } from './gestureHooks/useZoomOnDoubleTapReset';
 import { initializeZoomInteractionConfig } from './initializeZoomInteractionConfig';
@@ -245,6 +246,8 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = (pluginDat
   }, [removeIsInteracting]);
 
   // Add events
+  useRegisterZoomGestures(pluginData);
+
   usePanOnDrag(pluginData, setZoomDataCallback);
 
   usePanOnPressAndDrag(pluginData, setZoomDataCallback);

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
@@ -4,22 +4,25 @@ import {
   GestureManager,
   MoveGesture,
   PanGesture,
-  PinchGesture,
-  PressAndDragGesture,
   PressGesture,
-  TapAndDragGesture,
   TapGesture,
-  TurnWheelGesture,
+  type PinchGesture,
+  type PressAndDragGesture,
+  type TapAndDragGesture,
+  type TurnWheelGesture,
 } from '@mui/x-internal-gestures/core';
 import { type ChartPlugin } from '../../models';
 import {
   type UseChartInteractionListenerSignature,
   type AddInteractionListener,
+  type RegisterGestures,
   type UpdateZoomInteractionListeners,
 } from './useChartInteractionListener.types';
 
 const preventDefault = (event: Event) => event.preventDefault();
 
+// The zoom gestures are part of the type, but their implementations are only
+// registered (and bundled) by the plugins using them. See `registerGestures`.
 type GestureManagerTyped = GestureManager<
   string,
   | PanGesture<'pan'>
@@ -72,40 +75,6 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
             threshold: 0,
             maxPointers: 1,
           }),
-          // Zoom gestures
-          new PanGesture({
-            name: 'zoomPan',
-            threshold: 0,
-            preventIf: ['zoomTapAndDrag', 'zoomPressAndDrag'],
-          }),
-          new PinchGesture({
-            name: 'zoomPinch',
-            threshold: 5,
-          }),
-          new TurnWheelGesture({
-            name: 'zoomTurnWheel',
-            sensitivity: 0.01,
-            initialDelta: 1,
-            passive: false,
-          }),
-          new TurnWheelGesture({
-            name: 'panTurnWheel',
-            sensitivity: 0.5,
-            passive: false,
-          }),
-          new TapAndDragGesture({
-            name: 'zoomTapAndDrag',
-            dragThreshold: 10,
-          }),
-          new PressAndDragGesture({
-            name: 'zoomPressAndDrag',
-            dragThreshold: 10,
-            preventIf: ['zoomPinch'],
-          }),
-          new TapGesture({
-            name: 'zoomDoubleTapReset',
-            taps: 2,
-          }),
         ],
       });
     }
@@ -117,23 +86,7 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
       return undefined;
     }
 
-    gestureManager.registerElement(
-      [
-        'pan',
-        'move',
-        'zoomPinch',
-        'zoomPan',
-        'zoomTurnWheel',
-        'panTurnWheel',
-        'tap',
-        'quickPress',
-        'zoomTapAndDrag',
-        'zoomPressAndDrag',
-        'zoomDoubleTapReset',
-        'brush',
-      ],
-      svg,
-    );
+    gestureManager.registerElement(['pan', 'move', 'tap', 'quickPress', 'brush'], svg);
 
     return () => {
       // Cleanup gesture manager
@@ -168,6 +121,28 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
     [chartsLayerContainerRef, gestureManagerRef],
   );
 
+  // Allows feature plugins (e.g. the pro zoom plugin) to register the gestures they
+  // need, so the gesture implementations are only bundled with the plugin using them.
+  // The core gestures are registered before feature plugins run their effects.
+  const registerGestures: RegisterGestures = React.useCallback(
+    (gestures) => {
+      const svg = chartsLayerContainerRef.current;
+      const gestureManager = gestureManagerRef.current;
+      if (!gestureManager || !svg) {
+        return;
+      }
+
+      gestureManager.addGestures(gestures);
+      gestureManager.registerElement(
+        gestures.map((gesture) => gesture.name) as Parameters<
+          GestureManagerTyped['registerElement']
+        >[0],
+        svg,
+      );
+    },
+    [chartsLayerContainerRef, gestureManagerRef],
+  );
+
   React.useEffect(() => {
     const svg = chartsLayerContainerRef.current;
 
@@ -188,6 +163,7 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
     instance: {
       addInteractionListener,
       updateZoomInteractionListeners,
+      registerGestures,
     },
   };
 };

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.types.ts
@@ -1,4 +1,5 @@
 import {
+  type Gesture,
   type MoveEvent,
   type PanEvent,
   type PanGestureOptions,
@@ -136,6 +137,8 @@ export interface UseChartInteractionListenerParameters {}
 
 export interface UseChartInteractionListenerState {}
 
+export type RegisterGestures = (gestures: Gesture<string>[]) => void;
+
 export interface UseChartInteractionListenerInstance {
   /**
    * Adds an interaction listener to the SVG element.
@@ -151,6 +154,14 @@ export interface UseChartInteractionListenerInstance {
    * @param options The options to apply to the interaction.
    */
   updateZoomInteractionListeners: UpdateZoomInteractionListeners;
+  /**
+   * Registers additional gestures on the chart interaction element.
+   * Allows feature plugins to register the gestures they need, so the gesture
+   * implementations are only bundled together with the plugin using them.
+   *
+   * @param gestures The gestures to register.
+   */
+  registerGestures: RegisterGestures;
 }
 
 export type UseChartInteractionListenerSignature = ChartPluginSignature<{

--- a/packages/x-data-grid-premium/src/components/columnMenu/menuItems/GridColumnMenuAggregationItem.tsx
+++ b/packages/x-data-grid-premium/src/components/columnMenu/menuItems/GridColumnMenuAggregationItem.tsx
@@ -56,7 +56,8 @@ function GridColumnMenuAggregationItem(props: GridColumnMenuItemProps) {
   const handleAggregationItemChange = (event: React.ChangeEvent<unknown>) => {
     const newAggregationItem = (event.target as HTMLSelectElement | null)?.value || undefined;
     const currentModel = gridAggregationModelSelector(apiRef);
-    const { [colDef.field]: columnItem, ...otherColumnItems } = currentModel;
+    const otherColumnItems = { ...currentModel };
+    delete otherColumnItems[colDef.field];
     const newModel: GridAggregationModel =
       newAggregationItem == null
         ? otherColumnItems

--- a/packages/x-data-grid/src/hooks/core/pipeProcessing/useGridPipeProcessing.ts
+++ b/packages/x-data-grid/src/hooks/core/pipeProcessing/useGridPipeProcessing.ts
@@ -112,7 +112,8 @@ export const useGridPipeProcessing = (apiRef: RefObject<GridPrivateApiCommon>) =
     cache.current[group]!.appliers[id] = applier;
 
     return () => {
-      const { [id]: removedGroupApplier, ...otherAppliers } = cache.current[group]!.appliers;
+      const otherAppliers = { ...cache.current[group]!.appliers };
+      delete otherAppliers[id];
       cache.current[group]!.appliers = otherAppliers;
     };
   }, []);

--- a/packages/x-data-grid/src/hooks/core/strategyProcessing/useGridStrategyProcessing.ts
+++ b/packages/x-data-grid/src/hooks/core/strategyProcessing/useGridStrategyProcessing.ts
@@ -78,8 +78,8 @@ export const useGridStrategyProcessing = (apiRef: RefObject<GridPrivateApiCommon
   >(
     (strategyName, processorName, processor: GridStrategyProcessor<any>) => {
       const cleanup = () => {
-        const { [strategyName]: removedPreProcessor, ...otherProcessors } =
-          strategiesCache.current[processorName]!;
+        const otherProcessors = { ...strategiesCache.current[processorName]! };
+        delete otherProcessors[strategyName];
         strategiesCache.current[processorName] = otherProcessors;
       };
 

--- a/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
@@ -296,7 +296,9 @@ export const useGridCellEditing = (
       if (newProps !== null) {
         newModel[id] = { ...newModel[id], [field]: { ...newProps } };
       } else {
-        const { [field]: fieldToRemove, ...otherFields } = newModel[id]; // Ensure that we have a new object, not a reference
+        // Ensure that we have a new object, not a reference
+        const otherFields = { ...newModel[id] };
+        delete otherFields[field];
         newModel[id] = otherFields;
         if (Object.keys(newModel[id]).length === 0) {
           delete newModel[id];

--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -673,7 +673,8 @@ export const useGridRowEditing = (
           newProps = { ...newProps, isProcessingProps: true };
           updateOrDeleteFieldState(id, field, newProps);
 
-          const { [field]: ignoredField, ...otherFieldsProps } = editingState[id];
+          const otherFieldsProps = { ...editingState[id] };
+          delete otherFieldsProps[field];
 
           const promise = Promise.resolve(
             column.preProcessEditCellProps({
@@ -719,7 +720,8 @@ export const useGridRowEditing = (
           updateOrDeleteFieldState(id, thisField, fieldProps);
 
           editingState = gridEditRowsStateSelector(apiRef);
-          const { [thisField]: ignoredField, ...otherFieldsProps } = editingState[id];
+          const otherFieldsProps = { ...editingState[id] };
+          delete otherFieldsProps[thisField];
 
           const promise = Promise.resolve(
             fieldColumn.preProcessEditCellProps({

--- a/packages/x-internal-gestures/src/core/GestureManager.ts
+++ b/packages/x-internal-gestures/src/core/GestureManager.ts
@@ -169,6 +169,24 @@ export class GestureManager<
   }
 
   /**
+   * Add gesture templates to the manager's template registry after construction.
+   * Templates already registered under the same name are kept untouched, making
+   * this method safe to call from React effects that may run multiple times.
+   *
+   * This allows optional gestures to be registered lazily by the feature using
+   * them, so they are only bundled when that feature is.
+   *
+   * @param gestures - The gesture instances to use as templates
+   */
+  public addGestures(gestures: Gesture<GestureName>[]): void {
+    gestures.forEach((gesture) => {
+      if (!this.gestureTemplates.has(gesture.name)) {
+        this.addGestureTemplate(gesture);
+      }
+    });
+  }
+
+  /**
    * Add a gesture template to the manager's template registry.
    * Templates serve as prototypes that can be cloned for individual elements.
    *

--- a/packages/x-internals/src/store/useStore.ts
+++ b/packages/x-internals/src/store/useStore.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 /* We need to import the shim because React 17 does not support the `useSyncExternalStore` API.
  * More info: https://github.com/mui/mui-x/issues/18303#issuecomment-2958392341 */
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 import reactMajor from '../reactMajor';
 import type { ReadonlyStore } from './Store';
 
@@ -65,10 +64,25 @@ function useStoreLegacy(
   a2?: unknown,
   a3?: unknown,
 ): unknown {
-  return useSyncExternalStoreWithSelector(
-    store.subscribe,
-    store.getSnapshot,
-    store.getSnapshot,
-    (state) => selector(state, a1, a2, a3),
-  );
+  // React 18 requires the snapshot to be cached: returning a new reference from
+  // `getSnapshot` on consecutive calls without an intervening store update would
+  // trigger an infinite render loop. We memoize the selection on the snapshot
+  // identity, like `useSyncExternalStoreWithSelector` does, without paying for
+  // the full `with-selector` module.
+  const getSelection = React.useMemo(() => {
+    let hasMemo = false;
+    let memoizedSnapshot: unknown;
+    let memoizedSelection: unknown;
+    return () => {
+      const snapshot = store.getSnapshot();
+      if (!hasMemo || !Object.is(memoizedSnapshot, snapshot)) {
+        hasMemo = true;
+        memoizedSnapshot = snapshot;
+        memoizedSelection = selector(snapshot, a1, a2, a3);
+      }
+      return memoizedSelection;
+    };
+  }, [store, selector, a1, a2, a3]);
+
+  return useSyncExternalStore(store.subscribe, getSelection, getSelection);
 }


### PR DESCRIPTION
The with-selector shim module is only needed to cache the selection on
the snapshot identity, which React 18 requires to avoid render loops.
Implement that memoization directly on top of the plain
useSyncExternalStore shim and drop the with-selector module from the
bundle of every package using the store.