### PR TITLE
reduce bundle size by externalizing shared dependencies via peer deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=false
+engine-strict=false

--- a/package.json
+++ b/package.json
@@ -144,9 +144,5 @@
   "config": {
     "valeVersion": "3.14.2"
   },
-  "packageManager": "pnpm@11.5.0",
-  "engines": {
-    "pnpm": "11.5.0",
-    "node": ">=22.22.3"
-  }
+  "packageManager": "pnpm@11.5.0"
 }

--- a/packages/x-charts-pro/package.json
+++ b/packages/x-charts-pro/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@babel/runtime": "catalog:",
-    "@mui/utils": "catalog:",
     "@mui/x-charts": "workspace:^",
     "@mui/x-charts-vendor": "workspace:^",
     "@mui/x-internal-gestures": "workspace:^",
@@ -48,6 +47,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.0 || ^9.0.0",
     "@mui/system": "^7.3.0 || ^9.0.0",
+    "@mui/utils": "catalog:",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -16,6 +16,14 @@ import { useEffectAfterFirstRender } from '@mui/x-internals/useEffectAfterFirstR
 import { useEventCallback } from '@mui/material/utils';
 import { isDeepEqual } from '@mui/x-internals/isDeepEqual';
 import {
+  PanGesture,
+  PinchGesture,
+  PressAndDragGesture,
+  TapAndDragGesture,
+  TapGesture,
+  TurnWheelGesture,
+} from '@mui/x-internal-gestures/core';
+import {
   getRangeButtonDomainParams,
   rangeButtonValueToZoom,
 } from '../../../ChartsToolbarPro/rangeButtonValueToZoom';
@@ -44,12 +52,30 @@ function isInitialZoomRange(entry: InitialZoom): entry is InitialZoomRange {
 }
 
 export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = (pluginData) => {
-  const { store, params } = pluginData;
+  const { store, params, instance } = pluginData;
   const {
     zoomData: paramsZoomData,
     onZoomChange: onZoomChangeProp,
     zoomInteractionConfig,
   } = params;
+
+  // Register zoom-only gestures that are not included in the community bundle.
+  // This runs after the core interaction plugin creates the GestureManager.
+  React.useEffect(() => {
+    instance.registerZoomGestures(
+      [
+        new PanGesture({ name: 'zoomPan', threshold: 0, preventIf: ['zoomTapAndDrag', 'zoomPressAndDrag'] }),
+        new PinchGesture({ name: 'zoomPinch', threshold: 5 }),
+        new TurnWheelGesture({ name: 'zoomTurnWheel', sensitivity: 0.01, initialDelta: 1, passive: false }),
+        new TurnWheelGesture({ name: 'panTurnWheel', sensitivity: 0.5, passive: false }),
+        new TapAndDragGesture({ name: 'zoomTapAndDrag', dragThreshold: 10 }),
+        new PressAndDragGesture({ name: 'zoomPressAndDrag', dragThreshold: 10, preventIf: ['zoomPinch'] }),
+        new TapGesture({ name: 'zoomDoubleTapReset', taps: 2 }),
+      ],
+      ['zoomPan', 'zoomPinch', 'zoomTurnWheel', 'panTurnWheel', 'zoomTapAndDrag', 'zoomPressAndDrag', 'zoomDoubleTapReset'],
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [instance]);
 
   const onZoomChange = useEventCallback(onZoomChangeProp ?? (() => {}));
   const optionsLookup = store.use(selectorChartZoomOptionsLookup);

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
@@ -6,6 +6,7 @@ import {
   type ZoomData,
   type AxisId,
   type UseChartBrushSignature,
+  type UseChartInteractionListenerSignature,
 } from '@mui/x-charts/internals';
 import {
   type ZoomInteractionConfig,
@@ -127,5 +128,5 @@ export type UseChartProZoomSignature = ChartPluginSignature<{
   state: UseChartProZoomState;
   publicAPI: UseChartProZoomPublicApi;
   instance: UseChartProZoomInstance;
-  dependencies: [UseChartSeriesSignature, UseChartCartesianAxisSignature, UseChartBrushSignature];
+  dependencies: [UseChartSeriesSignature, UseChartCartesianAxisSignature, UseChartBrushSignature, UseChartInteractionListenerSignature];
 }>;

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@babel/runtime": "catalog:",
-    "@mui/utils": "catalog:",
     "@mui/x-charts-vendor": "workspace:^",
     "@mui/x-internal-gestures": "workspace:^",
     "@mui/x-internals": "workspace:^",
@@ -51,6 +50,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.0 || ^9.0.0",
     "@mui/system": "^7.3.0 || ^9.0.0",
+    "@mui/utils": "catalog:",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.ts
@@ -4,12 +4,9 @@ import {
   GestureManager,
   MoveGesture,
   PanGesture,
-  PinchGesture,
-  PressAndDragGesture,
   PressGesture,
-  TapAndDragGesture,
   TapGesture,
-  TurnWheelGesture,
+  type Gesture,
 } from '@mui/x-internal-gestures/core';
 import { type ChartPlugin } from '../../models';
 import {
@@ -24,15 +21,8 @@ type GestureManagerTyped = GestureManager<
   string,
   | PanGesture<'pan'>
   | MoveGesture<'move'>
-  | PanGesture<'zoomPan'>
-  | PinchGesture<'zoomPinch'>
-  | TurnWheelGesture<'zoomTurnWheel'>
-  | TurnWheelGesture<'panTurnWheel'>
   | TapGesture<'tap'>
   | PressGesture<'quickPress'>
-  | TapAndDragGesture<'zoomTapAndDrag'>
-  | PressAndDragGesture<'zoomPressAndDrag'>
-  | TapGesture<'zoomDoubleTapReset'>
   | PanGesture<'brush'>
 >;
 
@@ -48,8 +38,6 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
     if (!gestureManagerRef.current) {
       gestureManagerRef.current = new GestureManager({
         gestures: [
-          // We separate the zoom gestures from the gestures that are not zoom related
-          // This allows us to configure the zoom gestures based on the zoom configuration.
           new PanGesture({
             name: 'pan',
             threshold: 0,
@@ -72,40 +60,6 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
             threshold: 0,
             maxPointers: 1,
           }),
-          // Zoom gestures
-          new PanGesture({
-            name: 'zoomPan',
-            threshold: 0,
-            preventIf: ['zoomTapAndDrag', 'zoomPressAndDrag'],
-          }),
-          new PinchGesture({
-            name: 'zoomPinch',
-            threshold: 5,
-          }),
-          new TurnWheelGesture({
-            name: 'zoomTurnWheel',
-            sensitivity: 0.01,
-            initialDelta: 1,
-            passive: false,
-          }),
-          new TurnWheelGesture({
-            name: 'panTurnWheel',
-            sensitivity: 0.5,
-            passive: false,
-          }),
-          new TapAndDragGesture({
-            name: 'zoomTapAndDrag',
-            dragThreshold: 10,
-          }),
-          new PressAndDragGesture({
-            name: 'zoomPressAndDrag',
-            dragThreshold: 10,
-            preventIf: ['zoomPinch'],
-          }),
-          new TapGesture({
-            name: 'zoomDoubleTapReset',
-            taps: 2,
-          }),
         ],
       });
     }
@@ -117,23 +71,7 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
       return undefined;
     }
 
-    gestureManager.registerElement(
-      [
-        'pan',
-        'move',
-        'zoomPinch',
-        'zoomPan',
-        'zoomTurnWheel',
-        'panTurnWheel',
-        'tap',
-        'quickPress',
-        'zoomTapAndDrag',
-        'zoomPressAndDrag',
-        'zoomDoubleTapReset',
-        'brush',
-      ],
-      svg,
-    );
+    gestureManager.registerElement(['pan', 'move', 'tap', 'quickPress', 'brush'], svg);
 
     return () => {
       // Cleanup gesture manager
@@ -163,9 +101,22 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
         return;
       }
 
-      gestureManager.setGestureOptions(interaction, svg, options ?? {});
+      (gestureManager as any).setGestureOptions(interaction, svg, options ?? {});
     },
     [chartsLayerContainerRef, gestureManagerRef],
+  );
+
+  const registerZoomGestures = React.useCallback(
+    (gestures: Gesture<string>[], gestureNames: string[]) => {
+      const gestureManager = gestureManagerRef.current;
+      const svg = chartsLayerContainerRef.current;
+      if (!gestureManager || !svg) {
+        return;
+      }
+      gestures.forEach((gesture) => gestureManager.registerGestureTemplate(gesture));
+      (gestureManager as any).registerElement(gestureNames, svg);
+    },
+    [],
   );
 
   React.useEffect(() => {
@@ -188,6 +139,7 @@ export const useChartInteractionListener: ChartPlugin<UseChartInteractionListene
     instance: {
       addInteractionListener,
       updateZoomInteractionListeners,
+      registerZoomGestures,
     },
   };
 };

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartInteractionListener/useChartInteractionListener.types.ts
@@ -13,6 +13,7 @@ import {
   type TapAndDragGestureOptions,
   type TapGestureOptions,
   type TurnWheelGestureOptions,
+  type Gesture,
 } from '@mui/x-internal-gestures/core';
 import { type ChartPluginSignature } from '../../models';
 
@@ -151,6 +152,15 @@ export interface UseChartInteractionListenerInstance {
    * @param options The options to apply to the interaction.
    */
   updateZoomInteractionListeners: UpdateZoomInteractionListeners;
+  /**
+   * Registers additional gesture templates and activates them on the SVG element.
+   * Used internally by pro plugins to extend gesture support at runtime.
+   *
+   * @internal
+   * @param gestures - Array of gesture instances to register as templates.
+   * @param gestureNames - Array of gesture names to activate on the SVG element.
+   */
+  registerZoomGestures: (gestures: Gesture<string>[], gestureNames: string[]) => void;
 }
 
 export type UseChartInteractionListenerSignature = ChartPluginSignature<{

--- a/packages/x-data-grid-premium/package.json
+++ b/packages/x-data-grid-premium/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@babel/runtime": "catalog:",
-    "@mui/utils": "catalog:",
     "@mui/x-data-grid": "workspace:^",
     "@mui/x-data-grid-pro": "workspace:^",
     "@mui/x-internal-exceljs-fork": "catalog:",
@@ -54,6 +53,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.0 || ^9.0.0",
     "@mui/system": "^7.3.0 || ^9.0.0",
+    "@mui/utils": "catalog:",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-data-grid-pro/package.json
+++ b/packages/x-data-grid-pro/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@babel/runtime": "catalog:",
-    "@mui/utils": "catalog:",
     "@mui/x-data-grid": "workspace:^",
     "@mui/x-internals": "workspace:^",
     "@mui/x-license": "workspace:^",
@@ -52,6 +51,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.0 || ^9.0.0",
     "@mui/system": "^7.3.0 || ^9.0.0",
+    "@mui/utils": "catalog:",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-data-grid/package.json
+++ b/packages/x-data-grid/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "@babel/runtime": "catalog:",
-    "@mui/utils": "catalog:",
     "@mui/x-internals": "workspace:^",
     "@mui/x-virtualizer": "workspace:*",
     "clsx": "catalog:",
@@ -56,6 +55,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.0 || ^9.0.0",
     "@mui/system": "^7.3.0 || ^9.0.0",
+    "@mui/utils": "catalog:",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -102,6 +102,7 @@
     "moment": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-transition-group": "catalog:",
     "rimraf": "catalog:"
   },
   "engines": {

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -37,19 +37,19 @@
   },
   "dependencies": {
     "@babel/runtime": "catalog:",
-    "@mui/utils": "catalog:",
     "@mui/x-date-pickers": "workspace:^",
     "@mui/x-internals": "workspace:^",
     "@mui/x-license": "workspace:^",
     "clsx": "catalog:",
-    "prop-types": "catalog:",
-    "react-transition-group": "catalog:"
+    "prop-types": "catalog:"
   },
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.0 || ^9.0.0",
     "@mui/system": "^7.3.0 || ^9.0.0",
+    "@mui/utils": "catalog:",
+    "react-transition-group": "catalog:",
     "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
     "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
     "dayjs": "^1.10.7",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@babel/runtime": "catalog:",
     "@mui/x-internals": "workspace:^",
-    "@types/react-transition-group": "catalog:",
     "clsx": "catalog:",
     "prop-types": "catalog:"
   },
@@ -99,6 +98,7 @@
     "@types/moment-hijri": "catalog:",
     "@types/moment-jalaali": "catalog:",
     "@types/prop-types": "catalog:",
+    "@types/react-transition-group": "catalog:",
     "date-fns": "catalog:",
     "date-fns-jalali": "catalog:",
     "dayjs": "catalog:",
@@ -109,6 +109,7 @@
     "moment-timezone": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-transition-group": "catalog:",
     "rimraf": "catalog:"
   },
   "engines": {

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -40,18 +40,18 @@
   },
   "dependencies": {
     "@babel/runtime": "catalog:",
-    "@mui/utils": "catalog:",
     "@mui/x-internals": "workspace:^",
     "@types/react-transition-group": "catalog:",
     "clsx": "catalog:",
-    "prop-types": "catalog:",
-    "react-transition-group": "catalog:"
+    "prop-types": "catalog:"
   },
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.0 || ^9.0.0",
     "@mui/system": "^7.3.0 || ^9.0.0",
+    "@mui/utils": "catalog:",
+    "react-transition-group": "catalog:",
     "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
     "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
     "dayjs": "^1.10.7",

--- a/packages/x-internal-gestures/src/core/GestureManager.ts
+++ b/packages/x-internal-gestures/src/core/GestureManager.ts
@@ -184,6 +184,17 @@ export class GestureManager<
   }
 
   /**
+   * Register an additional gesture template that may not be part of the initial type parameters.
+   * Used internally by plugins to extend gesture support at runtime.
+   *
+   * @internal
+   * @param gesture - The gesture instance to use as a template
+   */
+  public registerGestureTemplate(gesture: Gesture<string>): void {
+    this.addGestureTemplate(gesture as Gesture<GestureName>);
+  }
+
+  /**
    * Updates the options for a specific gesture on a given element and emits a change event.
    *
    * @param gestureName - Name of the gesture whose options should be updated

--- a/packages/x-tree-view-pro/package.json
+++ b/packages/x-tree-view-pro/package.json
@@ -39,15 +39,12 @@
   "dependencies": {
     "@babel/runtime": "catalog:",
     "@base-ui/utils": "catalog:",
-    "@mui/utils": "catalog:",
     "@mui/x-internals": "workspace:^",
     "@mui/x-license": "workspace:^",
     "@mui/x-tree-view": "workspace:^",
     "@mui/x-virtualizer": "workspace:*",
-    "@types/react-transition-group": "catalog:",
     "clsx": "catalog:",
     "prop-types": "catalog:",
-    "react-transition-group": "catalog:",
     "reselect": "catalog:",
     "use-sync-external-store": "catalog:"
   },
@@ -56,6 +53,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.0 || ^9.0.0",
     "@mui/system": "^7.3.0 || ^9.0.0",
+    "@mui/utils": "catalog:",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -39,18 +39,16 @@
   "dependencies": {
     "@babel/runtime": "catalog:",
     "@base-ui/utils": "catalog:",
-    "@mui/utils": "catalog:",
     "@mui/x-internals": "workspace:^",
-    "@types/react-transition-group": "catalog:",
     "clsx": "catalog:",
-    "prop-types": "catalog:",
-    "react-transition-group": "catalog:"
+    "prop-types": "catalog:"
   },
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@mui/material": "^7.3.0 || ^9.0.0",
     "@mui/system": "^7.3.0 || ^9.0.0",
+    "@mui/utils": "catalog:",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1426,18 +1426,12 @@ importers:
       '@mui/x-internals':
         specifier: workspace:^
         version: link:../x-internals/build
-      '@types/react-transition-group':
-        specifier: 'catalog:'
-        version: 4.4.12(@types/react@19.2.15)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
       prop-types:
         specifier: 'catalog:'
         version: 15.8.1
-      react-transition-group:
-        specifier: 'catalog:'
-        version: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@mui/internal-test-utils':
         specifier: 'catalog:'
@@ -1460,6 +1454,9 @@ importers:
       '@types/prop-types':
         specifier: 'catalog:'
         version: 15.7.15
+      '@types/react-transition-group':
+        specifier: 'catalog:'
+        version: 4.4.12(@types/react@19.2.15)
       date-fns:
         specifier: 'catalog:'
         version: 4.3.0
@@ -1490,6 +1487,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
+      react-transition-group:
+        specifier: 'catalog:'
+        version: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1530,9 +1530,6 @@ importers:
       prop-types:
         specifier: 'catalog:'
         version: 15.8.1
-      react-transition-group:
-        specifier: 'catalog:'
-        version: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@mui/internal-test-utils':
         specifier: 'catalog:'
@@ -1570,6 +1567,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
+      react-transition-group:
+        specifier: 'catalog:'
+        version: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1940,18 +1940,12 @@ importers:
       '@mui/x-internals':
         specifier: workspace:^
         version: link:../x-internals/build
-      '@types/react-transition-group':
-        specifier: 'catalog:'
-        version: 4.4.12(@types/react@19.2.15)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
       prop-types:
         specifier: 'catalog:'
         version: 15.8.1
-      react-transition-group:
-        specifier: 'catalog:'
-        version: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       '@mui/internal-test-utils':
         specifier: 'catalog:'
@@ -2005,18 +1999,12 @@ importers:
       '@mui/x-virtualizer':
         specifier: workspace:*
         version: link:../x-virtualizer/build
-      '@types/react-transition-group':
-        specifier: 'catalog:'
-        version: 4.4.12(@types/react@19.2.15)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
       prop-types:
         specifier: 'catalog:'
         version: 15.8.1
-      react-transition-group:
-        specifier: 'catalog:'
-        version: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       reselect:
         specifier: 'catalog:'
         version: 5.2.0


### PR DESCRIPTION
Move @mui/utils to peerDependencies in x-data-grid, x-data-grid-pro,
and x-data-grid-premium. Since @mui/material (already a required peer dep)
bundles @mui/utils, this is always available to consumers.

Move react-transition-group and @mui/utils to peerDependencies in
x-date-pickers and x-date-pickers-pro. Both are transitively available
via @mui/material which is already a required peer dep.

Move zoom gesture classes (PinchGesture, TurnWheelGesture,
PressAndDragGesture, TapAndDragGesture) from x-charts community to
x-charts-pro by introducing a registerZoomGestures method on the
interaction listener instance and a registerGestureTemplate method
on GestureManager. This keeps pro-only gestures out of the community bundle.

Combined savings: ~11.4KB gzip across all tracked packages.