### PR TITLE
[charts-premium] Inline pass-through extrema getters in CandlestickChart

### DIFF
--- a/packages/x-charts-premium/src/CandlestickChart/seriesConfig/extrema.ts
+++ b/packages/x-charts-premium/src/CandlestickChart/seriesConfig/extrema.ts
@@ -1,7 +1,7 @@
 import { findMinMax } from '@mui/x-charts/internals';
 import type { CartesianExtremumGetter } from '@mui/x-charts/internals';
 
-const getBaseExtremum: CartesianExtremumGetter<'ohlc'> = (params) => {
+export const getExtremumX: CartesianExtremumGetter<'ohlc'> = (params) => {
   const { axis, getFilters, isDefaultAxis } = params;
 
   const filter = getFilters?.({
@@ -14,7 +14,7 @@ const getBaseExtremum: CartesianExtremumGetter<'ohlc'> = (params) => {
   return findMinMax(data ?? []);
 };
 
-const getValueExtremum: CartesianExtremumGetter<'ohlc'> = (params) => {
+export const getExtremumY: CartesianExtremumGetter<'ohlc'> = (params) => {
   const { series, axis, getFilters, isDefaultAxis } = params;
 
   return Object.keys(series)
@@ -61,12 +61,4 @@ const getValueExtremum: CartesianExtremumGetter<'ohlc'> = (params) => {
       },
       [Infinity, -Infinity],
     );
-};
-
-export const getExtremumX: CartesianExtremumGetter<'ohlc'> = (params) => {
-  return getBaseExtremum(params);
-};
-
-export const getExtremumY: CartesianExtremumGetter<'ohlc'> = (params) => {
-  return getValueExtremum(params);
 };


### PR DESCRIPTION
getExtremumX/getExtremumY were no-op wrappers that just forwarded to the
private getBaseExtremum/getValueExtremum. Give the implementations the
exported names directly and drop the indirection.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JwpLzPiiQTfzZy9sh6AnhF