### PR TITLE
[docs] Fix broken social preview image on shared docs links

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -255,6 +255,11 @@ const CSB_CONFIG = {
 
 const DOCS_CONFIG: DocsConfig = {
   ...DEFAULT_DOCS_CONFIG,
+  // Absolute origin used to build canonical and social-preview URLs (og:url,
+  // og:image, twitter:image). Without it the docs infra interpolates
+  // `undefined` into those meta tags, so social platforms (X, etc.) fail to
+  // load the preview image when a docs page is shared.
+  hostUrl: 'https://mui.com',
 };
 
 function useThemeWrapper() {


### PR DESCRIPTION
The docs `AppLayoutHead` builds `og:url`, `og:image`, and `twitter:image`
by interpolating `hostUrl` from the docs config. `DOCS_CONFIG` spread
`DEFAULT_DOCS_CONFIG` without setting `hostUrl`, so the value was
`undefined` and every social meta tag resolved to
`undefined/edge-functions/og-image?...`. Social platforms (X, etc.)
could not load that URL, so shared links showed no preview image.

Set `hostUrl` to `https://mui.com` so the meta tags resolve to valid
absolute URLs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012auoswyk6M4Ji3R5y4U8U3